### PR TITLE
Change company name in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-   Copyright 2017 karriere.at Informationsdienstleistung GmbH
+   Copyright 2017 karriere.at GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Company name of karriere.at is officially changed to
karriere.at GmbH