### PR TITLE
Fix handling CallbackBindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.1] - 2020-10-14
+## [4.0.1] - 2020-10-15
 ### Fixed
 - Still handle CallbackBinding when property name doesn't match a JSON fieldname.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.0] - 2002-10-06
+## [4.0.1] - 2020-10-14
+### Fixed
+- Still handle CallbackBinding when property name doesn't match a JSON fieldname.
+
+## [4.0.0] - 2020-10-06
 ### Added
 - support for magic class properties
 - auto casing for json field - class properties mapping

--- a/tests/ClassBindingsTest.php
+++ b/tests/ClassBindingsTest.php
@@ -3,6 +3,7 @@
 namespace Karriere\JsonDecoder\Tests;
 
 use Karriere\JsonDecoder\Binding;
+use Karriere\JsonDecoder\Bindings\CallbackBinding;
 use Karriere\JsonDecoder\Bindings\FieldBinding;
 use Karriere\JsonDecoder\ClassBindings;
 use Karriere\JsonDecoder\Exceptions\InvalidBindingException;
@@ -54,5 +55,18 @@ class ClassBindingsTest extends TestCase
         $this->expectException(JsonValueException::class);
 
         $classBindings->decode(['firstname' => 'John'], new Person());
+    }
+
+    /** @test */
+    public function it_executes_callback_bindings_when_property_name_is_not_contained_in_json_fields()
+    {
+        $classBindings = new ClassBindings(new JsonDecoder());
+        $classBindings->register(new CallbackBinding('somePropertyName', function () {
+            return 'yes';
+        }));
+
+        $person = $classBindings->decode(['firstname' => 'John'], new Person());
+
+        $this->assertEquals('yes', $person->somePropertyName);
     }
 }


### PR DESCRIPTION
CallbackBindings are the only Bindings where you don't need to define a JSON fieldname. Also handle the Binding if the property name of the binding doesn't match a JSON fieldname.

#37 