### PR TITLE
Fix handling CallbackBinding when key is contained in JSON fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.2] - 2020-10-15
+### Fixed
+- Another issue where CallbackBinding wasn't handled.
+
 ## [4.0.1] - 2020-10-15
 ### Fixed
 - Still handle CallbackBinding when property name doesn't match a JSON fieldname.

--- a/src/ClassBindings.php
+++ b/src/ClassBindings.php
@@ -50,7 +50,7 @@ class ClassBindings
                 $binding  = $this->bindings[$fieldName];
                 $property = Property::create($instance, $this->bindings[$fieldName]->property());
                 $this->handleBinding($binding, $property, $data);
-            } else {
+            } elseif (!$this->hasCallbackBinding($fieldName)) { // callback bindings are handled below
                 if ($this->jsonDecoder->shouldAutoCase()) {
                     $property = $this->autoCase($fieldName, $instance);
 
@@ -67,10 +67,8 @@ class ClassBindings
         }
 
         foreach ($this->callbackBindings as $propertyName => $binding) {
-            if (!in_array($propertyName, $jsonFieldNames)) {
-                $property = Property::create($instance, $propertyName);
-                $this->handleBinding($binding, $property, $data);
-            }
+            $property = Property::create($instance, $propertyName);
+            $this->handleBinding($binding, $property, $data);
         }
 
         return $instance;
@@ -102,6 +100,11 @@ class ClassBindings
     public function hasBinding($property)
     {
         return array_key_exists($property, $this->bindings);
+    }
+
+    public function hasCallbackBinding(string $propertyName): bool
+    {
+        return array_key_exists($propertyName, $this->callbackBindings);
     }
 
     /**

--- a/tests/ClassBindingsTest.php
+++ b/tests/ClassBindingsTest.php
@@ -27,6 +27,20 @@ class ClassBindingsTest extends TestCase
     }
 
     /** @test */
+    public function it_registers_a_callback_binding()
+    {
+        $classBindings = new ClassBindings(new JsonDecoder());
+
+        $this->assertFalse($classBindings->hasBinding('field'));
+        $this->assertFalse($classBindings->hasCallbackBinding('field'));
+
+        $classBindings->register(new CallbackBinding('field', function () {}));
+
+        $this->assertFalse($classBindings->hasBinding('field'));
+        $this->assertTrue($classBindings->hasCallbackBinding('field'));
+    }
+
+    /** @test */
     public function it_fails_to_register_a_not_compatible_binding_class()
     {
         $classBindings = new ClassBindings(new JsonDecoder());
@@ -55,6 +69,19 @@ class ClassBindingsTest extends TestCase
         $this->expectException(JsonValueException::class);
 
         $classBindings->decode(['firstname' => 'John'], new Person());
+    }
+
+    /** @test */
+    public function it_executes_callback_bindings_when_property_name_is_contained_in_json_fields()
+    {
+        $classBindings = new ClassBindings(new JsonDecoder());
+        $classBindings->register(new CallbackBinding('firstname', function ($data) {
+            return $data['firstname'] . ' Doe';
+        }));
+
+        $person = $classBindings->decode(['firstname' => 'John'], new Person());
+
+        $this->assertEquals('John Doe', $person->firstname());
     }
 
     /** @test */


### PR DESCRIPTION
As previously the CallbackBindings where moved into a separate property in the ClassBindings class, they need to be called independently of the keys being present in the JSON fields, because the hasBindings method doesn't check the separate callbackBindings class property.
When iterating over the JSON fields check for registered CallbackBinding, so it doesn't execute handleRaw() unnecessarily before the CallbackBinding is handled below.

#37 