### PR TITLE
Implementation of PHP 8 Attributes to create Transformers

### DIFF
--- a/src/Attributes/AttributeInterface.php
+++ b/src/Attributes/AttributeInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Karriere\JsonDecoder\Attributes;
+
+interface AttributeInterface
+{
+    /**
+     * Gets the binding associated with the attribute.
+     *
+     * @return Karriere\JsonDecoder\Binding
+     */
+    public function getBinding(string $propertyName);
+}

--- a/src/Attributes/JsonAlias.php
+++ b/src/Attributes/JsonAlias.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Karriere\JsonDecoder\Attributes;
+
+use Attribute;
+use Karriere\JsonDecoder\Bindings\AliasBinding;
+
+#[Attribute]
+class JsonAlias implements AttributeInterface
+{
+    public function __construct(public string $property, public bool $isRequired = false)
+    {
+    }
+
+    public function getBinding(string $propertyName)
+    {
+        return new AliasBinding($propertyName, $this->property, $this->isRequired);
+    }
+}

--- a/src/Attributes/JsonArray.php
+++ b/src/Attributes/JsonArray.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Karriere\JsonDecoder\Attributes;
+
+use Attribute;
+use Karriere\JsonDecoder\Bindings\ArrayBinding;
+
+#[Attribute]
+class JsonArray implements AttributeInterface
+{
+    public function __construct(
+        public string $className,
+        public ?string $attribute = null,
+        public bool $isRequired = false
+    ) {
+    }
+
+    public function getBinding(string $propertyName)
+    {
+        $attribute = $this->attribute ?? $propertyName;
+
+        return new ArrayBinding($propertyName, $attribute, $this->className, $this->isRequired);
+    }
+}

--- a/src/Attributes/JsonCallback.php
+++ b/src/Attributes/JsonCallback.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Karriere\JsonDecoder\Attributes;
+
+use Attribute;
+use Karriere\JsonDecoder\Bindings\StaticCallbackBinding;
+
+#[Attribute]
+class JsonCallback implements AttributeInterface
+{
+    public function __construct(public string $callbackClass, public string $callbackMethod)
+    {
+    }
+
+    public function getBinding(string $propertyName)
+    {
+        return new StaticCallbackBinding($propertyName, [$this->callbackClass, $this->callbackMethod]);
+    }
+}

--- a/src/Attributes/JsonClass.php
+++ b/src/Attributes/JsonClass.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Karriere\JsonDecoder\Attributes;
+
+use Attribute;
+use Karriere\JsonDecoder\Bindings\FieldBinding;
+
+#[Attribute]
+class JsonClass implements AttributeInterface
+{
+    public function __construct(public string $className, public ?string $attribute = null)
+    {
+    }
+
+    public function getBinding(string $propertyName)
+    {
+        $attribute = $this->attribute ?? $propertyName;
+
+        return new FieldBinding($propertyName, $attribute, $this->className);
+    }
+}

--- a/src/Attributes/JsonDateTime.php
+++ b/src/Attributes/JsonDateTime.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Karriere\JsonDecoder\Attributes;
+
+use Attribute;
+use Karriere\JsonDecoder\Bindings\DateTimeBinding;
+
+#[Attribute]
+class JsonDateTime implements AttributeInterface
+{
+    public function __construct(
+        public ?string $attribute = null,
+        public bool $isRequired = false,
+        public string $format = \DateTime::ATOM
+    ) {
+    }
+
+    public function getBinding(string $propertyName)
+    {
+        $attribute = $this->attribute ?? $propertyName;
+
+        return new DateTimeBinding($propertyName, $attribute, $this->isRequired, $this->format);
+    }
+}

--- a/src/Attributes/JsonHideUnmapped.php
+++ b/src/Attributes/JsonHideUnmapped.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Karriere\JsonDecoder\Attributes;
+
+use Attribute;
+
+#[Attribute]
+class JsonHideUnmapped
+{
+}

--- a/src/Bindings/HideUnmappedBinding.php
+++ b/src/Bindings/HideUnmappedBinding.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Karriere\JsonDecoder\Bindings;
+
+use Karriere\JsonDecoder\Binding;
+use Karriere\JsonDecoder\JsonDecoder;
+use Karriere\JsonDecoder\Property;
+
+class HideUnmappedBinding extends Binding
+{
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function bind(JsonDecoder $jsonDecoder, ?array $jsonData, Property $property)
+    {
+    }
+}

--- a/src/Bindings/StaticCallbackBinding.php
+++ b/src/Bindings/StaticCallbackBinding.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Karriere\JsonDecoder\Bindings;
+
+use Karriere\JsonDecoder\Binding;
+use Karriere\JsonDecoder\JsonDecoder;
+use Karriere\JsonDecoder\Property;
+
+class StaticCallbackBinding extends Binding
+{
+    /**
+     * @var callable
+     */
+    private $callback;
+
+    /**
+     * StaticCallbackBinding constructor.
+     */
+    public function __construct(string $property, array $callback)
+    {
+        parent::__construct($property, null, null, false);
+        $this->callback = $callback;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(array $jsonData): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function bind(JsonDecoder $jsonDecoder, ?array $jsonData, Property $property)
+    {
+        $property->set(call_user_func($this->callback, $jsonData, $jsonDecoder));
+    }
+}

--- a/src/Property.php
+++ b/src/Property.php
@@ -76,4 +76,9 @@ class Property
     {
         return $this->propertyName;
     }
+
+    public function isNewProperty()
+    {
+        return $this->property == null;
+    }
 }


### PR DESCRIPTION
I started using this library and saw the possibilities that could be created by using Attributes.  I put some code together and wanted to see what you thought of it.  Consider it a starting point rather than a ready to merge PR.

This implementation would allow for complex use cases without ever having to write or register a transformer.  Using Attributes allows individual class parameters to be assigned different bindings right in the parent class.

Here's some example code:
```
class Person
{
    #[JsonAlias("fullname")] // AliasBinding from json attribute 'fullname'
    public string $name;

    #[JsonClass(Address::class, 'street_name')] // FieldBinding to the Address class on the 'street_name' attribute
    public Address $address;

    #[JsonArray(Pet::class)] // ArrayBinding to the Pet class
    public array $pets;

    #[JsonDateTime(format: "Y-m-d")] // DateTimeBinding with the specified format
    public \DateTime $birthday;

    #[JsonCallback(Person::class, "parseTime")] // CallbackBinding that calls Person::parseTime
    public array $time;
}

$jsonDecoder = new JsonDecoder();
$jsonDecoder->scanAndRegister(Person::class);
$data = ".....";
$person = $jsonDecoder->decode($data, Person::class);
```

I feel like that's pretty self explanatory, but please let me know if anything isn't clear.

One caveat I ran in to is that it's not possible to pass `callable` objects to an attribute, only constants.  To get around that and still be able to implement `CallbackBinding` as an attribute, it needs to be limited to only static methods, passed as `[$className, $methodName]`.

Additionally, any classes transformed to (Address or Pet in the example) can also have their own attributes set, which will be automatically added to the decoder.

I also implemented two ways to optionally not add unmapped parameters from Json to an object.  The first is passing a second bool to the `JsonDecoder` constructor, ex: `new JsonDecoder(false, true);`, which would hide unmapped attributes for all classes used by that decoder object.  Alternatively, a class can be prefixed by the `JsonHideUnmapped` attribute to hide unmapped attributes for just that class.

I'm curious what you think about all this, any for any suggestions you might have.