### PR TITLE
Array key support for ArrayBinding

### DIFF
--- a/src/Bindings/ArrayBinding.php
+++ b/src/Bindings/ArrayBinding.php
@@ -18,8 +18,8 @@ class ArrayBinding extends Binding
             $values = [];
 
             if (is_array($data)) {
-                foreach ($data as $item) {
-                    $values[] = $jsonDecoder->decodeArray($item, $this->type);
+                foreach ($data as $key  => $item) {
+                    $values[$key] = $jsonDecoder->decodeArray($item, $this->type);
                 }
 
                 $property->set($values);

--- a/tests/Bindings/ArrayBindingTest.php
+++ b/tests/Bindings/ArrayBindingTest.php
@@ -42,6 +42,36 @@ class ArrayBindingTest extends TestCase
     }
 
     /** @test */
+    public function itBindsAnArrayPreservingKeys()
+    {
+        $binding  = new ArrayBinding('address', 'addresses', Address::class);
+        $person   = new Person();
+        $property = Property::create($person, 'address');
+
+        $jsonData = [
+            'addresses' => [
+                'address key #1' => [
+                    'street' => 'Street 1',
+                    'city'   => 'City 1',
+                ],
+                'address key #2' =>  [
+                    'street' => 'Street 2',
+                    'city'   => 'City 2',
+                ],
+            ],
+        ];
+
+        $binding->bind(new JsonDecoder(), $jsonData, $property);
+
+        $this->assertIsArray($person->address());
+        $this->assertCount(2, $person->address());
+        $this->assertEquals('Street 1', $person->address()['address key #1']->street());
+        $this->assertEquals('City 1', $person->address()['address key #1']->city());
+        $this->assertEquals('Street 2', $person->address()['address key #2']->street());
+        $this->assertEquals('City 2', $person->address()['address key #2']->city());
+    }
+
+    /** @test */
     public function itSkipsANotAvailableField()
     {
         $binding  = new ArrayBinding('address', 'addresses', Address::class);

--- a/tests/Bindings/ArrayBindingTest.php
+++ b/tests/Bindings/ArrayBindingTest.php
@@ -44,19 +44,19 @@ class ArrayBindingTest extends TestCase
     /** @test */
     public function itBindsAnArrayPreservingKeys()
     {
-        $binding  = new ArrayBinding('address', 'addresses', Address::class);
-        $person   = new Person();
+        $binding = new ArrayBinding('address', 'addresses', Address::class);
+        $person  = new Person();
         $property = Property::create($person, 'address');
 
         $jsonData = [
             'addresses' => [
                 'address key #1' => [
                     'street' => 'Street 1',
-                    'city'   => 'City 1',
+                    'city' => 'City 1',
                 ],
-                'address key #2' =>  [
+                'address key #2' => [
                     'street' => 'Street 2',
-                    'city'   => 'City 2',
+                    'city' => 'City 2',
                 ],
             ],
         ];


### PR DESCRIPTION
copy of https://github.com/karriereat/json-decoder/pull/52 which i closed, so can come off 'bugfix' branch


## What/Why

This PR enables array keys to be preserved when arrays are parsed via an ArrayBinding. If array keys are not present nothing changes, but if they do exist they will be preserved. 

## Testing

Duplicated `ArrayBindingTest::itBindsAnArray()` to `itBindsAnArrayPreservingKeys` but the address` $jsonData` that gets binded now has keys. Then when accessing they various properties for assertion the `$person->address` array data needs to be accessed w/ the correct array key. 